### PR TITLE
STM as a cli plugin

### DIFF
--- a/bin/cli.ml
+++ b/bin/cli.ml
@@ -1,14 +1,16 @@
-type frontend = Default | Monolith
+type frontend = Default | Monolith | STM
 
 let get_channel = function None -> stdout | Some path -> open_out path
 
 let frontend_printer ppf = function
   | Default -> Fmt.string ppf "Default"
   | Monolith -> Fmt.string ppf "Monolith"
+  | STM -> Fmt.string ppf "STM"
 
 let frontend_parser = function
   | "default" -> Ok Default
   | "monolith" -> Ok Monolith
+  | "STM" -> Ok STM
   | s -> Error (`Msg (Fmt.str "Error: `%s' is not a valid argument" s))
 
 let main frontend input output () =
@@ -19,6 +21,7 @@ let main frontend input output () =
     match frontend with
     | Default -> Ortac_default.generate input channel
     | Monolith -> Ortac_monolith.generate input channel
+    | STM -> Ortac_STM.generate input channel
   with Gospel.Warnings.Error e ->
     Fmt.epr "%a@." Gospel.Warnings.pp e;
     exit 1

--- a/bin/cli.mli
+++ b/bin/cli.mli
@@ -1,5 +1,5 @@
 (* Left empty on purpose. *)
 
-type frontend = Default | Monolith
+type frontend = Default | Monolith | STM
 
 val main : frontend -> string -> string option -> unit -> unit

--- a/bin/dune
+++ b/bin/dune
@@ -1,11 +1,9 @@
-(executables
- (names myexe) 
- (preprocess
-  (pps ppx_jane ppx_deriving.show ppxlib.metaquot))
+(executable
+ (name cli)
+ (public_name ortac)
+ (package ortac)
  (libraries
-qcheck 
-ocaml-compiler-libs.shadow  
-cmdliner
+  cmdliner
   fmt
   fmt.cli
   fmt.tty
@@ -13,16 +11,5 @@ cmdliner
   ortac_default
   ortac_core
   ortac_monolith
-ortac_runtime
-ortac_stm 
   ppxlib
-pp_loc
-ppx_jane
-  ppxlib.ast)
-)
-(env
-  (dev
-    (flags (:standard -w -27 -w -32 -w -34 -w -33
-	-w -26 -w -11
-))))
-
+  ppxlib.ast))

--- a/bin/ortac_STM.ml
+++ b/bin/ortac_STM.ml
@@ -1,7 +1,7 @@
 open Ortac_core
 
 
-module S = Map.Make (String)
+(* module S = Map.Make (String) *)
 
 
 let signature ~runtime ~module_name namespace (s : Gospel.Tast.signature) =
@@ -14,7 +14,7 @@ let signature ~runtime ~module_name namespace (s : Gospel.Tast.signature) =
   (* print_endline("translations after phase 1 are:");
      Core.Sexp.output_hum stdout (Drv.sexp_of_sil translated.translations); *)
   let stm =  Phase2.stm translated in
-  Phase3.structure runtime stm 
+  Phase3.structure runtime stm
 (*      (map_of_list [("field1", Ast3.List Ast3.Integer);
                                           ("field2", Ast3.String)])
                                           in
@@ -32,21 +32,4 @@ let generate path output =
     Core.Sexp.output_hum stdout (Gospel.Tast.sexp_of_signature sigs); *)
     signature ~runtime:"Ortac_runtime" ~module_name (List.hd env)
       sigs
-     |> Fmt.pf output "%a@." Ppxlib_ast.Pprintast.structure 
-
-
-
-(* let _ = Cli.main Cli.Default path None () <-- so annoying
-that this doesn't work, ask jan*)
-
-let main () =
-   let inpath = "atom.mli" in
-   (* let outchannel = stdout in*)
-   let channel = stdout in generate inpath channel 
-(* 
-  (try Ortac_default.generate inpath outchannel
-  with Gospel.Warnings.Error e ->
-    Fmt.epr "%a@." Gospel.Warnings.pp e;
-    exit 1) *)
-
-let _  = main ()
+     |> Fmt.pf output "%a@." Ppxlib_ast.Pprintast.structure

--- a/bin/ortac_STM.mli
+++ b/bin/ortac_STM.mli
@@ -1,0 +1,4 @@
+val generate : string -> out_channel -> unit
+(** [generate path output] generates the code of the tests corresponding to the
+    specifications present in [path] in the monolith configuration and prints it
+    on the [output] channel *)


### PR DESCRIPTION
This PR makes the STM plugin work with the cli interface similarly to Monolith, e.g.:
```
dune exec -- bin/cli.exe --frontend=STM bin/atom.ml
```
In a separate PR we should consider collecting the code of the STM plugin in a separate folder, incl. ortac_STM.{ml,mli}