### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,40 @@
+name: Main CI workflow
+
+on:
+  pull_request:
+  push:
+  schedule:
+    # Prime the caches every Monday
+    - cron: 0 1 * * MON
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+        ocaml-compiler:
+#          - 4.08.x
+#          - 4.09.x
+#          - 4.10.x
+#          - 4.11.x
+#          - 4.12.x
+#          - 4.13.x
+           - 4.14.x
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          opam-depext: false
+
+      - run: opam install . --deps-only --with-test
+      - run: opam exec -- dune build bin

--- a/ortac.opam
+++ b/ortac.opam
@@ -31,6 +31,8 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "fmt"
   "ppxlib" {>= "0.26.0"}
+  "ppx_jane" {>= "0.15.0"}
+  "core"     {>= "0.15.0"}
   "gospel"
   "alcotest" {with-test}
   "pprint" {with-test}

--- a/ortac.opam
+++ b/ortac.opam
@@ -33,6 +33,7 @@ depends: [
   "ppxlib" {>= "0.26.0"}
   "ppx_jane" {>= "0.15.0"}
   "core"     {>= "0.15.0"}
+  "qcheck"   {>= "0.19.1"}
   "gospel"
   "alcotest" {with-test}
   "pprint" {with-test}


### PR DESCRIPTION
This PR adds a simple GitHub Actions CI which installs the needed dependencies (as listed in ortac.opam) and tries to `dune build bin`
To get it working I needed to add a couple of dependencies (qcheck, core, ppx_jane).
We should discuss how many of these are needed and potentially reduce them in a separate PR.